### PR TITLE
Clean up output. Return exit code 2 on exceptions.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,15 +32,18 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
     tty-color (0.6.0)
+    warning (1.3.0)
     yaml (0.2.1)
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   byebug (~> 11.0)
   no-lorem!
   rspec (~> 3.0)
+  warning (~> 1.3)
 
 BUNDLED WITH
    2.3.26

--- a/bin/no-lorem
+++ b/bin/no-lorem
@@ -6,4 +6,3 @@ $LOAD_PATH.unshift(libx) unless $LOAD_PATH.include?(libx)
 require 'no-lorem'
 
 NoLorem::Runner.new.go(ARGV)
-

--- a/lib/no-lorem/patrol.rb
+++ b/lib/no-lorem/patrol.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'warning'
+Warning.ignore(/warning: parser/)
+
 require 'byebug'
 require 'parser/current'
 
@@ -51,7 +54,7 @@ module NoLorem
     def examine_files(files)
       files = [files] if files.is_a? String
       files.each do |fname|
-        examine(File.read(fname), context: fname)
+        examine(File.read(fname, encoding: "utf-8"), context: fname)
       end
       issues?
     end

--- a/lib/no-lorem/runner.rb
+++ b/lib/no-lorem/runner.rb
@@ -42,9 +42,10 @@ module NoLorem
       print_denylists if verbose?
       process_files
     rescue => ex
-      puts ex.message
+      puts terminal.red("#{ex.message} (#{ex.class.name})")
       puts
       puts @option_parser
+      exit(2)
     end
 
     private
@@ -83,12 +84,12 @@ module NoLorem
           @options["verbose"] = true
         end
 
-        opts.on("-w", "--deny-word WORD", "Add word to deny list") do |word|
+        opts.on("-w", "--deny-word WORD", "Add word to denylist") do |word|
           @options["deny"]["words"] = [] unless @options["deny"]["words"]
           @options["deny"]["words"] << word
         end
 
-        opts.on("-C", "--deny-constant CONSTANT", "Add constant to deny list") do |constant|
+        opts.on("-C", "--deny-constant CONSTANT", "Add constant to denylist") do |constant|
           @options["deny"]["constants"] = [] unless @options["deny"]["words"]
           @options["deny"]["constants"] << constant
         end
@@ -108,7 +109,8 @@ module NoLorem
       if file = configuration_file
         config = YAML.load_file(file)
         puts "Using configuration file: #{file}"
-        @config = NoLorem.deep_merge_hashes(config, @options.except("config"))
+        @options.delete("config")
+        @config = NoLorem.deep_merge_hashes(config, @options)
       else
         @config = @options
       end
@@ -219,6 +221,8 @@ module NoLorem
         @config["deny"]["words"].each do |constant|
           puts terminal.blue(" - #{constant}")
         end
+      else
+        puts "No denylist for constants."
       end
     end
   end

--- a/lib/no-lorem/version.rb
+++ b/lib/no-lorem/version.rb
@@ -2,7 +2,7 @@
 
 module NoLorem
   module Version
-    STRING = '0.0.2'
+    STRING = '0.0.3'
 
     def self.version
       STRING

--- a/no-lorem.gemspec
+++ b/no-lorem.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("byebug", "~> 11.0")
+  s.add_development_dependency("warning", "~> 1.3")
 end


### PR DESCRIPTION
This is just a minor change: 
- Make sure exceptions raised by the tool (e.g. file not found) result in an non-zero exit code (2).
- Clean up output, remove warning from parser module, fix typos, etc.